### PR TITLE
preserve assets paths when fingerprinting;

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,10 @@ Fingerprint.prototype.getDestFilePath = function(filename) {
     md5.update(file);
     var hex = md5.digest('hex');
 
+    var dirname =  path.dirname(dest);
     var extname =  path.extname(dest);
     var basename =  path.basename(dest, extname);
-    return [basename, hex+extname].join(separator);
+    return dirname + "/" + [basename, hex+extname].join(separator);
   }
 
   var destFilePath = Filter.prototype.getDestFilePath.apply(this, arguments);


### PR DESCRIPTION
my use case is having the assets stored under the `assets/` directory, I'd like the fingerprinted version to end up in the same place.

@moudy, let me know what you think and thanks for this plugin :)
