### PR TITLE
fix error in getDestFilePath path.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ Fingerprint.prototype.processString = function(s) {
 };
 
 Fingerprint.prototype.getDestFilePath = function(filename) {
-  var filepath = path.join(this.inputTree.tmpDestDir, filename);
+  var filepath = path.join(this.inputTree.outputPath, filename);
   var separator = this.separator;
 
   function fingerprint(dest) {


### PR DESCRIPTION
TypeError: Arguments to path.join must be strings
at path.js:360:15
at Array.filter (native)
at Object.exports.join (path.js:358:36)
